### PR TITLE
Add assertions to Storage, Deadline and Event files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ application {
 shadowJar {
     archiveBaseName = "blob"
     archiveClassifier = null
-    archiveVersion = "v0.1"
+    archiveVersion = "v0.2"
     archiveFileName = "blob.jar"
 }
 

--- a/src/main/java/blob/Deadline.java
+++ b/src/main/java/blob/Deadline.java
@@ -11,6 +11,7 @@ public class Deadline extends Task {
     public Deadline(String name, boolean isDone, String deadline) {
         super(name,isDone);
         this.deadline = LocalDateTime.parse(deadline);
+        assert this.deadline.isAfter(LocalDateTime.now()) : "Deadline of task is already in the past!";
         super.type = "D";
     }
 

--- a/src/main/java/blob/Event.java
+++ b/src/main/java/blob/Event.java
@@ -15,7 +15,9 @@ public class Event extends Task {
     public Event(String name, boolean isDone, String start, String end) {
         super(name, isDone);
         this.start = LocalDateTime.parse(start);
+        assert this.start.isAfter(LocalDateTime.now()) : "This event's start time is already in the past!";
         this.end = LocalDateTime.parse(end);
+        assert this.end.isAfter(this.start) : "This event ends earlier than it begins? How can that be?";
         super.type = "E";
     }
 

--- a/src/main/java/blob/Storage.java
+++ b/src/main/java/blob/Storage.java
@@ -24,6 +24,10 @@ public class Storage {
                 FileWriter fw = new FileWriter(filePath);
                 fw.write("type,is_checked,task_name,time1,time2\n");
                 fw.close();
+            } else {
+                Scanner s = new Scanner(this.f);
+                String headers = s.nextLine();
+                assert headers.equals("type,is_checked,task_name,time1,time2\n") : "File headers are wrong!";
             }
         } catch (IOException e) {
             throw new RuntimeException("Database file was unable to be generated!");

--- a/src/main/java/database.csv
+++ b/src/main/java/database.csv
@@ -2,5 +2,4 @@ type,is_checked,task_name,time1,time2
 T,0,Eat Cup Noodles
 T,0,throw away the cup
 T,0,capture a pet hamster
-T,0,Save the Day!
 D,0,buy groceris,2024-09-03T14:00


### PR DESCRIPTION
CSV file for data storage is assumed to already have the proper headers, while the deadlines and relevant time periods entered by the user are assumed to be logical timings for both the deadline and event tasks created.

Inappropriate dates entered may render the tasks created useless and of little utility to the user, and may perhaps interfere with future iterations to the project which leverage on the created tasks having proper and logical dates.

Assertions have been added to ensure only deadlines past the time the user creates the task can be used. Same goes with the duration of event tasks as indicated by the user.